### PR TITLE
Add add_simulation_steps method to model.py 

### DIFF
--- a/agentpy/model.py
+++ b/agentpy/model.py
@@ -31,8 +31,14 @@ class Model(Object):
             :class:`Range`, :class:`IntRange`, and :class:`Values`.
             The following parameters will be used automatically:
 
-            - steps: Defines the maximum number of time-steps.
-            - seed: Used to initiate the model's random number generators.
+            - steps (int, optional):
+              Defines the maximum number of time-steps.
+              If none is passed, there will be no step limit.
+            - seed (int, optional):
+              Used to initiate the model's random number generators.
+              If none is passed, a random seed will be generated.
+            - report_seed (bool, optional):
+              Whether to document the random seed used (default True).
 
         **kwargs: Will be forwarded to :func:`Model.setup`.
 
@@ -292,6 +298,8 @@ class Model(Object):
                 seed = random.getrandbits(128)
 
         # Prepare random number generators
+        if not ('report_seed' in self.p and not self.p['report_seed']):
+            self.report('seed', seed)
         self.random = random.Random(seed)
         npseed = self.random.getrandbits(128)
         self.nprandom = np.random.default_rng(seed=npseed)


### PR DESCRIPTION
It is annoying when one has run a simulation to the end, that one cannot say "ok that was interesting, but I would now like to continue that same simulation for another n steps", with the current implementation that was not possible. I added the add_simulation_steps method in order to add extra steps to the end-time of the simulation. And modified the rest so that the same random gen state would be kept as well as the state of the simulation, and after calling add_simulation_steps one can then simply call run again which will keep the states of the simulation and simply continue the simulation as if it had been called with those extra steps from the start.